### PR TITLE
CORP decomposition of "point" Brier scores for clade 25A

### DIFF
--- a/analysis/generate_corp_decomposition.R
+++ b/analysis/generate_corp_decomposition.R
@@ -1,0 +1,229 @@
+# Analysis script to generate CORP decomposition of Brier scores using reliabilitydiag
+# This script loads predictions and observations from the targets pipeline,
+# processes them to create binary outcomes for each clade, and applies reliabilitydiag.
+
+library(targets)
+library(dplyr)
+library(tidyr)
+library(reliabilitydiag)
+library(ggplot2)
+library(ggrepel)
+library(geomtextpath)
+library(glue)
+library(arrow)
+
+# Load the necessary data from the targets store
+tar_load(clean_variant_data_final_all_states)
+all_model_outputs_for_heatmap <- read_parquet(
+    "~/variant-25a.parquet"
+)
+
+# Define function to run analysis and plot
+run_corp_analysis <- function(
+    location_subset_name,
+    loc_filter_fn,
+    model_selector,
+    output_file
+) {
+    cat(glue::glue("Processing {location_subset_name}...\n"))
+
+    # 1. Prepare Observations
+    obs <- clean_variant_data_final_all_states |>
+        filter(loc_filter_fn(location)) |>
+        rename(target_date = date, clade = clades_modeled) |>
+        group_by(location, target_date) |>
+        mutate(total_sequences = sum(sequences)) |>
+        ungroup() |>
+        select(location, target_date, clade, sequences, total_sequences)
+
+    # 2. Prepare Predictions
+    preds_long <- all_model_outputs_for_heatmap |>
+        filter(
+            loc_filter_fn(location),
+            output_type == "mean",
+            clade == "25A"
+        ) |>
+        select(model_id, location, nowcast_date, target_date, clade, value) |>
+        rename(prediction = value)
+
+    # Pivot to wide to handle model selection
+    preds_wide <- preds_long |>
+        pivot_wider(names_from = model_id, values_from = prediction)
+
+    # Apply model selection logic
+    preds_wide <- model_selector(preds_wide)
+
+    # 3. Join Predictions and Observations
+    data_joined_full <- preds_wide |>
+        inner_join(obs, by = c("location", "target_date", "clade"))
+
+    # Identify model columns
+    non_model_cols <- c(
+        "location",
+        "target_date",
+        "clade",
+        "sequences",
+        "total_sequences",
+        "nowcast_date"
+    )
+    model_cols <- setdiff(names(data_joined_full), non_model_cols)
+
+    # Drop rows with NAs in any of the selected models to ensure fair comparison
+    data_joined <- data_joined_full |>
+        drop_na(all_of(model_cols))
+
+    dropped_dates <- setdiff(
+        data_joined_full$nowcast_date,
+        data_joined$nowcast_date
+    )
+    if (length(dropped_dates) > 0) {
+        cli::cli_alert_info(
+            "Dropped nowcast dates {dropped_dates} due to missing model predictions."
+        )
+    }
+
+    if (nrow(data_joined) == 0) {
+        message(glue::glue(
+            "No data available for {location_subset_name} after filtering."
+        ))
+        return(NULL)
+    }
+
+    # 4. Expand data to binary observations
+    # Successes
+    df_success <- data_joined |>
+        select(all_of(c(model_cols, "sequences"))) |>
+        uncount(sequences) |>
+        mutate(y = 1)
+
+    # Failures
+    df_failure <- data_joined |>
+        mutate(failures = total_sequences - sequences) |>
+        select(all_of(c(model_cols, "failures"))) |>
+        uncount(failures) |>
+        mutate(y = 0)
+
+    # Combine
+    df_expanded <- bind_rows(df_success, df_failure)
+
+    # Extract predictions (X) and observations (y)
+    X <- df_expanded[model_cols]
+    y <- df_expanded$y
+
+    cat("Running reliabilitydiag...\n")
+    rd <- reliabilitydiag(X, y = y)
+
+    # 5. Collect results
+    corp_summary <- summary(rd) |>
+        rename(model_id = forecast) |>
+        as_tibble() |>
+        mutate(`R*` = (discrimination - miscalibration) / uncertainty)
+
+    print(corp_summary)
+
+    # Calculate Brier Score
+    corp_summary <- corp_summary |>
+        mutate(brier_score = mean_score)
+
+    # Prepare for plotting
+    unc_val <- mean(corp_summary$uncertainty)
+    unc_str <- round(unc_val, 4)
+    min_date <- min(data_joined$nowcast_date)
+    max_date <- max(data_joined$nowcast_date)
+
+    brier_range <- range(corp_summary$brier_score)
+    brier_iso <- seq(
+        from = brier_range[1] - diff(brier_range) * 0.2,
+        to = brier_range[2] + diff(brier_range) * 0.2,
+        length.out = 10
+    )
+
+    iso <- data.frame(
+        intercept = unc_val - brier_iso,
+        slope = 1,
+        brier_iso = round(brier_iso, 4)
+    )
+
+    p <- ggplot(corp_summary) +
+        geom_abline(
+            data = iso,
+            aes(intercept = intercept, slope = slope),
+            color = "lightgray",
+            alpha = 0.5,
+            linewidth = 0.5
+        ) +
+        geom_labelabline(
+            data = iso,
+            aes(intercept = intercept, slope = slope, label = brier_iso),
+            color = "gray50",
+            hjust = 0.5,
+            size = 3,
+            text_only = TRUE,
+            boxcolour = NA,
+            straight = TRUE
+        ) +
+        geom_point(
+            aes(x = miscalibration, y = discrimination, color = model_id),
+            size = 3,
+            show.legend = FALSE
+        ) +
+        geom_text_repel(
+            aes(
+                x = miscalibration,
+                y = discrimination,
+                label = model_id,
+                color = model_id
+            ),
+            show.legend = FALSE,
+            max.overlaps = NA,
+            size = 4,
+            seed = 42
+        ) +
+        labs(
+            title = "CORP Decomposition of Brier Score",
+            subtitle = glue::glue(
+                "Location: {location_subset_name}; Variant: 25A; Dates: {min_date} to {max_date}; Uncertainty = {unc_str}"
+            ),
+            btitle = glue::glue(
+                "Location: {location_subset_name}; Variant: 25A; Uncertainty = {unc_str}"
+            ),
+            x = "Miscalibration (MCB) - Lower is better",
+            y = "Discrimination (DSC) - Higher is better"
+        ) +
+        theme_bw(base_size = 11) +
+        theme(
+            panel.grid.major = element_blank(),
+            panel.grid.minor = element_blank(),
+            aspect.ratio = 1,
+            legend.position = "bottom"
+        )
+
+    print(p)
+    ggsave(output_file, p, width = 8, height = 8)
+}
+
+# --- Run 1: California ---
+run_corp_analysis(
+    location_subset_name = "California",
+    loc_filter_fn = function(x) x == "CA",
+    model_selector = function(df) {
+        df |>
+            select(-any_of("CADPH-CATaMaran")) |>
+            filter(!is.na(`CADPH-CATaLog`))
+    },
+    output_file = "analysis/corp_decomposition_plot_CA.png"
+)
+
+# --- Run 2: Other States ---
+run_corp_analysis(
+    location_subset_name = "US ex CA",
+    loc_filter_fn = function(x) x != "CA",
+    model_selector = function(df) {
+        df |>
+            # Remove columns that are all NA (models not defined for these states)
+            select(where(~ !all(is.na(.)))) |>
+            # Explicitly remove CA models if they exist
+            select(-matches("CADPH"))
+    },
+    output_file = "analysis/corp_decomposition_plot_Other.png"
+)


### PR DESCRIPTION
As promised!

The motivation here is that I've been interested/excited lately about
CORP decomposition of scores. This is a version of the classic decomposition:

score = miscalibration - descrimination + uncertainty

for a negatively oriented score, so it's rewarded for better (i.e., lower) discrimination.
The particular CORP decomposition has some nice properties. See the paper
here for an explanation of why it should be preferred: https://arxiv.org/abs/2008.03033

## Approach

The algorithm is implemented in the `{reliabilitydiag}` package. All I
did was take the targets pipeline and pull out the model data and subset
to 25A.

I expanded out the variant frequencies to successes/failures for
scoring.

However -- the `all_model_outputs_for_heatmap` target was too big for me
to load into RAM and run anything else. I had to subset to 25A and
convert UGA-multicast from samples to means in DuckDB
and save it to a parquet. I imagine you don't have this RAM limitation
on your machine and could just run it.
[variant-25a.parquet.zip](https://github.com/user-attachments/files/23754765/variant-25a.parquet.zip)

## Results

<img width="2400" height="2400" alt="corp_decomposition_plot_CA" src="https://github.com/user-attachments/assets/59c2d40f-66f6-4de1-9fe9-56d38d1c0c9d" />
<img width="2400" height="2400" alt="corp_decomposition_plot_Other" src="https://github.com/user-attachments/assets/ecc5bb07-b407-43b8-afe9-56ab3a80d4e3" />

(plot formatting taken from https://arxiv.org/pdf/2311.14122 for their CRPS decomposition plots)

I really like the description in `?summary.reliabilitydiag`

>    ‘miscalibration’  a measure of miscalibration
                         (_how reliable is the prediction method?_),
                         smaller is better.
       ‘discrimination’  a measure of discrimination
                         (_how variable are the recalibrated predictions?_),
                         larger is better.
       ‘uncertainty’     the mean score of a constant prediction at the
                         value of the average observation.

There's more good stuff in there so take a look!

But my gist is something like "the HMLR and CADPH-CATaLog models have
more information content about clade 25A emergence than baseline after recalibration.
However, both are less reliable than baseline, with this miscalibration
severe enough in the HMLR model to reduce its score below baseline."

There are some fairly extensive limitations here:

* First and most importantly, this relies on the same approach as `brier_point`.
  It assumes "25A against all else" and scores on that, ignoring any
  multinomial structure.
    * But this decomposition doesn't work for the log score. See the second to last
       para of https://arxiv.org/pdf/2311.14122 for an explanation.
* It's also using only the mean forecasts, not the uncertainty. So this
  captures the structural binomial uncertainty but not the model
  uncertainty (I imagine this might particularly penalize the HMLR).
     * It's possible we could rectify this by including multiple samples
       from each model? I'm not sure and need to read through some more
       to see if that's ok.
* Needs to run on complete cases. I dropped CATaMaran because it wasn't present
  for the whole beginning bit of 25A and the decomposition isn't
  comparable across subsets of data.
* Manually took the mean over UGA-multicast samples. Not sure if this makes sense.

I promise I won't be offended if this doesn't make it in -- I really
did it for fun! If it's interesting enough to do more on, I'm happy  to try to stick this in your pipeline if RAM permits.
